### PR TITLE
放大字型並使用bootstrap style強化按鈕感

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -78,12 +78,15 @@ input {
 .btn {
   display: inline-block;
   width: auto;
-  padding: 5px;
+  /*padding: 5px;*/
   border: 1px solid black;
-  color: black;
+  /*color: black;*/
 }
 .disabled {
   color: #ccc;
   border-color: #ccc;
   pointer-events: none;
+}
+.code-description {
+  font-size: 24px;
 }

--- a/index.html
+++ b/index.html
@@ -4,14 +4,19 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="format-detection" content="telephone=no">
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="css/style.css">
     <script src="js/jquery-3.5.1.min.js"></script>
   </head>
   <body>
     <div class="wrap withcode">
       <h2>疾管家實聯制工具</h2>
-      <p>
-        您目前登記的場所代碼為：<span class="no"></span><br>若此欄無代碼或代碼錯誤請勿送出</p><a class="btn disabled" href="sms:1922">送出實聯制登記簡訊</a>
+      <p class="code-description">
+        場所代碼：<span class="no"></span><br>若此欄無代碼或代碼錯誤請勿送出</p>
+        <div class="btn-wrapper text-center">
+          <a class="btn btn-primary btn-lg disabled" href="sms:1922">點我送出</a>
+        </div>
     </div>
     <div class="wrap nocode" style="display: nonde;">
       <h2>疾管家實聯制網址生成工具</h2>


### PR DESCRIPTION
1. 給長者試用後發現字型過小閱讀不易，
2. 送出的按鈕跟文字造型太接近，因此採用跟簡訊實聯制申請時一樣的 bootstrap 3 的造型。